### PR TITLE
Add better error message for clone command

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,7 +463,7 @@ Usage:
 
 Available Commands:
   add                 Add all repositories from a local directory to Gogs
-  clone-local         Clone all repos from GitHub organization into a local directory
+  clone               Clone all repos from GitHub organization into a local directory
   completion          Generate the autocompletion script for the specified shell
   create-access-token Create an access token with a user and password
   create-public-key   Create a public key to use git ssh

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -88,7 +88,6 @@ func add(cmd *cobra.Command, args []string) {
 			// Add the Gogs remote
 			cmd := exec.Command("git", "remote", "add", "gogs", gogsRepoURL)
 			if err = cmd.Run(); err != nil {
-				fmt.Println("err:", err)
 				return fmt.Errorf("failed to add Gogs remote %s: %w", gogsRepoURL, err)
 			}
 

--- a/cmd/clone.go
+++ b/cmd/clone.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"log"
@@ -14,7 +15,7 @@ import (
 )
 
 var cloneCmd = &cobra.Command{
-	Use:   "clone-local",
+	Use:   "clone",
 	Short: "Clone all repos from GitHub organization into a local directory",
 	Long:  "Clone all repos from GitHub organization into a local directory. Duplicate clone will fail: exit status 128",
 	Run:   clone,
@@ -64,8 +65,10 @@ func clone_(repoName, cloneURL string) error {
 
 	// Use the git command to clone the GitHub repository and then push to the Gogs repository
 	cmd := exec.Command("git", "clone", "--mirror", cloneURL, repoDir)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to clone GitHub repository: %w", err)
+		return fmt.Errorf("failed to clone GitHub repository, error: %w, %s", err, stderr.String())
 	}
 
 	return nil


### PR DESCRIPTION
1. Rename script command `clone-local` to `clone`.
2. Add better error message for clone command.
